### PR TITLE
Fix a tiny typo

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -112,8 +112,7 @@ When a user successfully logs in, they will be redirected to the previously requ
 
 As for the `userDetailsService()` method, it sets up an in-memory user store with a single user. That user is given a username of "user", a password of "password", and a role of "USER".
 
-Now we need to create the login page. There's already a v
-iew controller for the "login" view, so you only need to create the login view itself:
+Now we need to create the login page. There's already a view controller for the "login" view, so you only need to create the login view itself:
 
 `src/main/resources/templates/login.html`
 [source,html]


### PR DESCRIPTION
Hello,

This pull request fixes a tiny typo. It stems from 340b885 ; there doesn't seem to be any reason for splitting the line but this produces a space between the "v" and the "iew" in the final HTML.

Have a nice day.