### PR TITLE
Added @Override annotation in MvcConfig.java

### DIFF
--- a/complete/src/main/java/com/example/securingweb/MvcConfig.java
+++ b/complete/src/main/java/com/example/securingweb/MvcConfig.java
@@ -7,6 +7,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class MvcConfig implements WebMvcConfigurer {
 
+	@Override
 	public void addViewControllers(ViewControllerRegistry registry) {
 		registry.addViewController("/home").setViewName("home");
 		registry.addViewController("/").setViewName("home");


### PR DESCRIPTION
There is no warning when I mistype method name.
The interface doesn't force to override '[addViewControllers()](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/servlet/config/annotation/WebMvcConfigurer.html#addViewControllers-org.springframework.web.servlet.config.annotation.ViewControllerRegistry-)' because it is default method. 
I think it helps us to prevent mistakes.  