### PR TITLE
Moves test dependency to test scope in gradle

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -113,7 +113,7 @@ the `dependencies` closure in `build.gradle`, as the following listing shows:
 [source,java]
 ----
 implementation 'org.springframework.boot:spring-boot-starter-security'
-implementation 'org.springframework.security:spring-security-test'
+testImplementation 'org.springframework.security:spring-security-test'
 ----
 ====
 

--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.security:spring-security-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation('org.springframework.boot:spring-boot-starter-test')
 }
 


### PR DESCRIPTION
Documentation and the code adds `org.springframework.security:spring-security-test` as dependency to main code in gradle build but it should be a test dependency like it is in maven. This PR fixes that.